### PR TITLE
aasm_column deprecated in aasm 4.2.0

### DIFF
--- a/lib/aasm_history/persistance/active_record.rb
+++ b/lib/aasm_history/persistance/active_record.rb
@@ -3,7 +3,7 @@ module AasmHistory
     module ActiveRecord
 
       def aasm_write_state state
-        previous_state = read_attribute(self.class.aasm_column)
+        previous_state = read_attribute(self.class.aasm.attribute_name)
         success = super state
         store_aasm_history state, previous_state if success
         success


### PR DESCRIPTION
Hi! I have been using your gem and I really like it. I have been getting the following deprecation warning from `aasm`:
```
[DEPRECATION] aasm_column is deprecated. Use aasm.attribute_name instead
```

This PR makes the update to use `aasm.attribute_name` as suggested by the warning. Thank you very much!